### PR TITLE
Refine types for view variables/parameters 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,9 +30,9 @@
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~3.1.0",
-        "phpunit/phpunit": "^10.5.45",
+        "phpunit/phpunit": "^10.5.57",
         "psalm/plugin-phpunit": "^0.19.5",
-        "vimeo/psalm": "^6.10.0"
+        "vimeo/psalm": "^6.13.1"
     },
     "suggest": {
         "mezzio/mezzio-laminasviewrenderer": "^2.0 to use the laminas-view PhpRenderer template renderer",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0b702eee92cb57d3b94a23ec9f94a827",
+    "content-hash": "2262b3d821b24dad06e17a32e182a1db",
     "packages": [],
     "packages-dev": [
         {
@@ -2548,16 +2548,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.55",
+            "version": "10.5.57",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "4b2d546b336876bd9562f24641b08a25335b06b6"
+                "reference": "8e7598bbb17bb5cd80728f4831d3f83223d3a6b3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/4b2d546b336876bd9562f24641b08a25335b06b6",
-                "reference": "4b2d546b336876bd9562f24641b08a25335b06b6",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/8e7598bbb17bb5cd80728f4831d3f83223d3a6b3",
+                "reference": "8e7598bbb17bb5cd80728f4831d3f83223d3a6b3",
                 "shasum": ""
             },
             "require": {
@@ -2581,7 +2581,7 @@
                 "sebastian/comparator": "^5.0.4",
                 "sebastian/diff": "^5.1.1",
                 "sebastian/environment": "^6.1.0",
-                "sebastian/exporter": "^5.1.2",
+                "sebastian/exporter": "^5.1.4",
                 "sebastian/global-state": "^6.0.2",
                 "sebastian/object-enumerator": "^5.0.0",
                 "sebastian/recursion-context": "^5.0.1",
@@ -2629,7 +2629,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.55"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.57"
             },
             "funding": [
                 {
@@ -2653,7 +2653,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-14T06:19:20+00:00"
+            "time": "2025-09-24T06:30:38+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -3444,16 +3444,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "5.1.2",
+            "version": "5.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "955288482d97c19a372d3f31006ab3f37da47adf"
+                "reference": "0735b90f4da94969541dac1da743446e276defa6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/955288482d97c19a372d3f31006ab3f37da47adf",
-                "reference": "955288482d97c19a372d3f31006ab3f37da47adf",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/0735b90f4da94969541dac1da743446e276defa6",
+                "reference": "0735b90f4da94969541dac1da743446e276defa6",
                 "shasum": ""
             },
             "require": {
@@ -3462,7 +3462,7 @@
                 "sebastian/recursion-context": "^5.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^10.0"
+                "phpunit/phpunit": "^10.5"
             },
             "type": "library",
             "extra": {
@@ -3510,15 +3510,27 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
                 "security": "https://github.com/sebastianbergmann/exporter/security/policy",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.2"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.4"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-03-02T07:17:12+00:00"
+            "time": "2025-09-24T06:09:11+00:00"
         },
         {
             "name": "sebastian/global-state",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="6.10.0@9c0add4eb88d4b169ac04acb7c679918cbb9c252">
+<files psalm-version="6.13.1@1e3b7f0a8ab32b23197b91107adc0a7ed8a05b51">
   <file src="src/TemplateRendererInterface.php">
     <PossiblyUnusedMethod>
       <code><![CDATA[addDefaultParam]]></code>

--- a/src/ArrayParametersTrait.php
+++ b/src/ArrayParametersTrait.php
@@ -6,9 +6,11 @@ namespace Mezzio\Template;
 
 use Traversable;
 
+use function assert;
 use function gettype;
 use function is_array;
 use function is_object;
+use function is_string;
 use function iterator_to_array;
 use function method_exists;
 use function sprintf;
@@ -58,7 +60,26 @@ trait ArrayParametersTrait
             '%s template adapter can only handle arrays, Traversables, and objects '
             . 'when rendering; received %s',
             static::class,
-            gettype($params)
+            gettype($params),
         ));
+    }
+
+    /**
+     * Performs parameter normalization to an array with runtime assertions that all keys are non-empty-string
+     *
+     * @return array<non-empty-string, mixed>
+     * @throws Exception\InvalidArgumentException
+     * @psalm-suppress MixedAssignment
+     */
+    private function normalizeParamsAsMap(mixed $params): array
+    {
+        $params = $this->normalizeParams($params);
+        $map    = [];
+        foreach ($params as $key => $value) {
+            assert(is_string($key) && $key !== '');
+            $map[$key] = $value;
+        }
+
+        return $map;
     }
 }

--- a/src/DefaultParamsTrait.php
+++ b/src/DefaultParamsTrait.php
@@ -11,8 +11,8 @@ use function array_replace_recursive;
  */
 trait DefaultParamsTrait
 {
-    /** @var array<string, array<string, mixed>> */
-    private $defaultParams = [];
+    /** @var array<non-empty-string, array<non-empty-string, mixed>> */
+    private array $defaultParams = [];
 
     /**
      * Add a default parameter to use with a template.
@@ -28,18 +28,20 @@ trait DefaultParamsTrait
      * If the default parameter existed previously, subsequent invocations with
      * the same template name and parameter name will overwrite.
      *
-     * @param string $templateName Name of template to which the param applies;
+     * @param non-empty-string $templateName Name of template to which the param applies;
      *     use TEMPLATE_ALL to apply to all templates.
-     * @param string $param Param name.
+     * @param non-empty-string $param Param name.
      * @throws Exception\InvalidArgumentException
      */
     public function addDefaultParam(string $templateName, string $param, mixed $value): void
     {
-        if (! $templateName) {
+        /** @psalm-suppress TypeDoesNotContainType Retaining defensive checks despite precise types */
+        if ($templateName === '') {
             throw new Exception\InvalidArgumentException('$templateName must be a non-empty string');
         }
 
-        if (! $param) {
+        /** @psalm-suppress TypeDoesNotContainType Retaining defensive checks despite precise types */
+        if ($param === '') {
             throw new Exception\InvalidArgumentException('$param must be a non-empty string');
         }
 
@@ -53,15 +55,16 @@ trait DefaultParamsTrait
     /**
      * Returns merged global, template-specific and given params
      *
-     * @template TKey of array-key
-     * @param array<TKey, mixed> $params
-     * @return array<TKey, mixed>
+     * @param non-empty-string $template
+     * @param array<non-empty-string, mixed> $params
+     * @return array<non-empty-string, mixed>
      */
     private function mergeParams(string $template, array $params): array
     {
         $globalDefaults   = $this->defaultParams[TemplateRendererInterface::TEMPLATE_ALL] ?? [];
         $templateDefaults = $this->defaultParams[$template] ?? [];
 
+        /** @psalm-var array<non-empty-string, mixed> */
         return array_replace_recursive($globalDefaults, $templateDefaults, $params);
     }
 }

--- a/src/TemplateRendererInterface.php
+++ b/src/TemplateRendererInterface.php
@@ -20,7 +20,7 @@ interface TemplateRendererInterface
      * Implementations MUST support the `namespace::template` naming convention,
      * and allow omitting the filename extension.
      *
-     * @param array<string, mixed>|object $params
+     * @param array<non-empty-string, mixed>|object $params
      */
     public function render(string $name, array|object $params = []): string;
 

--- a/test/ArrayParametersTraitTest.php
+++ b/test/ArrayParametersTraitTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace MezzioTest\Template;
 
 use ArrayIterator;
+use AssertionError;
 use Mezzio\Template\Exception\InvalidArgumentException;
 use MezzioTest\Template\TestAsset\ArrayParameters;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -54,8 +55,6 @@ final class ArrayParametersTraitTest extends TestCase
     /** @psalm-return array<string, array{scalar, string}> */
     public static function nonNullScalarParameters(): array
     {
-        // @codingStandardsIgnoreStart
-        //                  [scalar,       expected exception string]
         return [
             'true'       => [true,         'bool'],
             'false'      => [false,        'bool'],
@@ -65,16 +64,20 @@ final class ArrayParametersTraitTest extends TestCase
             'float'      => [1.1,          'double'],
             'string'     => ['view param', 'string'],
         ];
-        // @codingStandardsIgnoreEnd
     }
 
-    /** @param string $expectedString */
     #[DataProvider('nonNullScalarParameters')]
-    public function testNonNullScalarsRaiseAnException(mixed $scalar, $expectedString): void
+    public function testNonNullScalarsRaiseAnException(mixed $scalar, string $expectedString): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage($expectedString);
 
         $this->subject->normalize($scalar);
+    }
+
+    public function testThatListsWillCauseAssertionFailure(): void
+    {
+        $this->expectException(AssertionError::class);
+        $this->subject->normalize(['a', 'b', 'c']);
     }
 }

--- a/test/DefaultParamsTraitTest.php
+++ b/test/DefaultParamsTraitTest.php
@@ -79,6 +79,7 @@ final class DefaultParamsTraitTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('$templateName must be a non-empty string');
+        /** @psalm-suppress InvalidArgument */
         $this->defaultParams->addDefaultParam('', 'name', 'value');
     }
 
@@ -86,6 +87,7 @@ final class DefaultParamsTraitTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('$param must be a non-empty string');
+        /** @psalm-suppress InvalidArgument */
         $this->defaultParams->addDefaultParam('template', '', 'value');
     }
 }

--- a/test/StaticAnalysis/DefaultParameters.php
+++ b/test/StaticAnalysis/DefaultParameters.php
@@ -11,8 +11,8 @@ final class DefaultParameters
     use DefaultParamsTrait;
 
     /**
-     * @param array<string, mixed> $params
-     * @return array<string, mixed>
+     * @param array<non-empty-string, mixed> $params
+     * @return array<non-empty-string, mixed>
      */
     public function mergePreservesKeyType(array $params): array
     {

--- a/test/TestAsset/ArrayParameters.php
+++ b/test/TestAsset/ArrayParameters.php
@@ -10,9 +10,11 @@ final class ArrayParameters
 {
     use ArrayParametersTrait;
 
-    /** @param mixed $params */
-    public function normalize($params): array
+    /**
+     * @return array<non-empty-string, mixed>
+     */
+    public function normalize(mixed $params): array
     {
-        return $this->normalizeParams($params);
+        return $this->normalizeParamsAsMap($params);
     }
 }

--- a/test/TestAsset/DefaultParameters.php
+++ b/test/TestAsset/DefaultParameters.php
@@ -10,11 +10,17 @@ final class DefaultParameters
 {
     use DefaultParamsTrait;
 
+    /** @return array<non-empty-string, array<non-empty-string, mixed>> */
     public function getParameters(): array
     {
         return $this->defaultParams;
     }
 
+    /**
+     * @param non-empty-string $template
+     * @param array<non-empty-string, mixed> $params
+     * @return array<non-empty-string, mixed>
+     */
     public function mergeParameters(string $template, array $params): array
     {
         return $this->mergeParams($template, $params);

--- a/test/TestAsset/ViewModel.php
+++ b/test/TestAsset/ViewModel.php
@@ -6,13 +6,16 @@ namespace MezzioTest\Template\TestAsset;
 
 final class ViewModel
 {
+    /** @var array<non-empty-string, mixed> */
     private array $variables;
 
+    /** @param array<non-empty-string, mixed> $variables */
     public function __construct(array $variables)
     {
         $this->variables = $variables;
     }
 
+    /** @return array<non-empty-string, mixed> */
     public function getVariables(): array
     {
         return $this->variables;


### PR DESCRIPTION
All parameters and variables are now keyed with `non-empty-string`.

Considering keys were already `string`, this is not much of a stretch even though PHP will permit an array-key of `''`, it is impractical to think that anyone was keying their view variables with `''`